### PR TITLE
Integrate site scrapers and simplify workflow

### DIFF
--- a/parser/__init__.py
+++ b/parser/__init__.py
@@ -2,6 +2,7 @@
 
 from .extract import extract_units
 from .models import Site, Unit
+from .scrapers import available_scrapers
 from .sites import load_sites_yaml, parse_sites_yaml
 from .workflow import WorkflowResult, collect_units_from_sites, filter_units
 
@@ -14,4 +15,5 @@ __all__ = [
     "collect_units_from_sites",
     "filter_units",
     "WorkflowResult",
+    "available_scrapers",
 ]

--- a/parser/scrapers/__init__.py
+++ b/parser/scrapers/__init__.py
@@ -1,0 +1,45 @@
+"""Scraper registry mapping site slugs to callable fetchers."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+from parser.models import Unit
+
+ScraperFunc = Callable[[str], List[Unit]]
+
+
+def _load_default_scrapers() -> Dict[str, ScraperFunc]:
+    registry: Dict[str, ScraperFunc] = {}
+    missing: List[str] = []
+
+    try:
+        from .amsires_scraper import fetch_units as amsires_fetch
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        missing.append(getattr(exc, "name", "amsires_scraper dependency"))
+    else:
+        registry["amsires"] = amsires_fetch
+
+    try:
+        from .relisto_scraper import fetch_units as relisto_fetch
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        missing.append(getattr(exc, "name", "relisto_scraper dependency"))
+    else:
+        registry["relisto"] = relisto_fetch
+
+    if not registry and missing:
+        details = ", ".join(sorted(set(filter(None, missing))))
+        raise RuntimeError(
+            f"No scrapers available because required dependencies are missing: {details}"
+        )
+
+    return registry
+
+
+def available_scrapers() -> Dict[str, ScraperFunc]:
+    """Return a copy of the built-in scraper registry."""
+
+    return _load_default_scrapers().copy()
+
+
+__all__ = ["ScraperFunc", "available_scrapers"]

--- a/parser/scrapers/relisto_scraper.py
+++ b/parser/scrapers/relisto_scraper.py
@@ -1,10 +1,15 @@
-from pathlib import Path
+"""Scraper for Relisto rental listings."""
+
+from __future__ import annotations
+
 import re
-import requests
-from bs4 import BeautifulSoup
+import time
 from typing import List, Optional
 
-from parser.models import Unit  # Make sure this import works in your environment
+import requests
+from bs4 import BeautifulSoup
+
+from parser.models import Unit
 
 BASE_URL = "https://www.relisto.com/search/unfurnished/"
 
@@ -19,60 +24,67 @@ HEADERS = {
     "Connection": "keep-alive",
 }
 
-def clean_price(value: str):
+
+def clean_price(value: Optional[str]) -> Optional[int]:
     if value is None:
         return None
-    m = re.search(r"[\d,]+(?:\.\d+)?", value)
-    if not m:
+    match = re.search(r"[\d,]+(?:\.\d+)?", value)
+    if not match:
         return None
-    s = m.group(0).replace(",", "")
+    normalised = match.group(0).replace(",", "")
     try:
-        return int(float(s))
+        return int(float(normalised))
     except ValueError:
         return None
 
-def clean_float(value: str):
+
+def clean_float(value: Optional[str]) -> Optional[float]:
     if value is None:
         return None
-    m = re.search(r"\d+(?:\.\d+)?", value)
-    if not m:
+    match = re.search(r"\d+(?:\.\d+)?", value)
+    if not match:
         return None
     try:
-        return float(m.group(0))
+        return float(match.group(0))
     except ValueError:
         return None
+
 
 def set_page_number(url: str, page: int) -> str:
-    from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+    from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
     parsed = urlparse(url)
-    qs = parse_qs(parsed.query, keep_blank_values=True)
+    query = parse_qs(parsed.query, keep_blank_values=True)
     if page <= 1:
-        qs.pop("sf_paged", None)
+        query.pop("sf_paged", None)
     else:
-        qs["sf_paged"] = [str(page)]
-    new_query = urlencode(qs, doseq=True)
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, new_query, parsed.fragment))
+        query["sf_paged"] = [str(page)]
+    new_query = urlencode(query, doseq=True)
+    return urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path, parsed.params, new_query, parsed.fragment)
+    )
 
-def get_page(url: str, session: requests.Session, timeout=20):
-    resp = session.get(url, headers=HEADERS, timeout=timeout)
-    resp.raise_for_status()
-    return resp.text
 
-def parse_listings(html: str, base_url: str = BASE_URL) -> List[Unit]:
+def _get_page(url: str, session: requests.Session, timeout: int = 20) -> str:
+    response = session.get(url, headers=HEADERS, timeout=timeout)
+    response.raise_for_status()
+    return response.text
+
+
+def parse_listings(html: str, *, base_url: str = BASE_URL) -> List[Unit]:
     soup = BeautifulSoup(html, "lxml")
-    listings = []
-    for a in soup.select("a.listing-box"):
-        href = a.get("href")
-        url = href if href else None
-        if url:
-            url = requests.compat.urljoin(base_url, url)
+    listings: List[Unit] = []
 
-        data_beds = a.get("data-beds")
-        data_baths = a.get("data-baths")
-        data_price = a.get("data-price")
+    for anchor in soup.select("a.listing-box"):
+        href = anchor.get("href")
+        url = requests.compat.urljoin(base_url, href) if href else None
 
-        address = None
-        loc = a.select_one("h4.location")
+        data_beds = anchor.get("data-beds")
+        data_baths = anchor.get("data-baths")
+        data_price = anchor.get("data-price")
+
+        address: Optional[str] = None
+        loc = anchor.select_one("h4.location")
         if loc and loc.get_text(strip=True):
             address = loc.get_text(strip=True)
         if address is None and href and "/rentals/" in href:
@@ -81,46 +93,60 @@ def parse_listings(html: str, base_url: str = BASE_URL) -> List[Unit]:
 
         beds = clean_float(data_beds) if data_beds else None
         if beds is None:
-            beds_el = a.select_one(".item-beds .item-value")
+            beds_el = anchor.select_one(".item-beds .item-value")
             beds = clean_float(beds_el.get_text(strip=True)) if beds_el else None
 
         baths = clean_float(data_baths) if data_baths else None
         if baths is None:
-            baths_el = a.select_one(".item-baths .item-value")
+            baths_el = anchor.select_one(".item-baths .item-value")
             baths = clean_float(baths_el.get_text(strip=True)) if baths_el else None
 
         price = clean_price(data_price) if data_price else None
         if price is None:
-            price_el = a.select_one(".item-price .item-value")
+            price_el = anchor.select_one(".item-price .item-value")
             price = clean_price(price_el.get_text(strip=True)) if price_el else None
 
         if not address and not price and not url:
             continue
 
-        listings.append(Unit(
-            address=address,
-            bedrooms=beds,
-            bathrooms=baths,
-            rent=price,
-            neighborhood=None,
-            source_url=url,
-        ))
+        listings.append(
+            Unit(
+                address=address,
+                bedrooms=beds,
+                bathrooms=baths,
+                rent=price,
+                neighborhood=None,
+                source_url=url or base_url,
+            )
+        )
+
     return listings
 
-def parse_relisto_listings(pages: int = 1, sleep: float = 1.0) -> List[Unit]:
-    """Scrape Relisto unfurnished listings and return a list of Unit objects."""
-    session = requests.Session()
+
+def fetch_units(
+    url: str = BASE_URL,
+    *,
+    pages: int = 1,
+    delay: float = 1.0,
+    session: Optional[requests.Session] = None,
+    timeout: int = 20,
+) -> List[Unit]:
+    """Fetch Relisto listings from *url*, walking pagination up to *pages*."""
+
+    http_session = session or requests.Session()
     all_units: List[Unit] = []
+
     for page in range(1, max(1, pages) + 1):
-        url = set_page_number(BASE_URL, page)
-        try:
-            html = get_page(url, session=session)
-        except Exception:
-            continue
-        units = parse_listings(html, base_url=BASE_URL)
+        page_url = set_page_number(url, page)
+        html = _get_page(page_url, session=http_session, timeout=timeout)
+        units = parse_listings(html, base_url=url)
         if not units and page > 1:
             break
         all_units.extend(units)
-        import time
-        time.sleep(sleep)
+        if delay:
+            time.sleep(delay)
+
     return all_units
+
+
+__all__ = ["fetch_units", "parse_listings", "set_page_number"]


### PR DESCRIPTION
## Summary
- add a scraper registry and hook the AMS IRES / Relisto scrapers into the package
- update the workflow to invoke registered scrapers directly and drop HTML download plumbing
- simplify the CLI and tests to work with scraper-driven site collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddc132e660833092f1c7565603bc70