### PR TITLE
Add Anchor Realty scraper and tests

### DIFF
--- a/parser/scrapers/__init__.py
+++ b/parser/scrapers/__init__.py
@@ -21,6 +21,13 @@ def _load_default_scrapers() -> Dict[str, ScraperFunc]:
         registry["amsires"] = amsires_fetch
 
     try:
+        from .anchorealty_scraper import fetch_units as anchorealty_fetch
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        missing.append(getattr(exc, "name", "anchorealty_scraper dependency"))
+    else:
+        registry["anchorealty"] = anchorealty_fetch
+
+    try:
         from .relisto_scraper import fetch_units as relisto_fetch
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
         missing.append(getattr(exc, "name", "relisto_scraper dependency"))

--- a/parser/scrapers/anchorealty_scraper.py
+++ b/parser/scrapers/anchorealty_scraper.py
@@ -1,0 +1,165 @@
+"""Scraper for Anchor Realty rental listings."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from parser.models import Unit
+
+LISTINGS_URL = "https://anchorealtyinc.com/residential-rentals/"
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+}
+
+
+def _clean_price(text: Optional[str]) -> Optional[int]:
+    if not text:
+        return None
+    match = re.search(r"[\d,]+(?:\.\d+)?", text)
+    if not match:
+        return None
+    normalised = match.group(0).replace(",", "")
+    try:
+        return int(float(normalised))
+    except ValueError:
+        return None
+
+
+def _clean_float(text: Optional[str]) -> Optional[float]:
+    if not text:
+        return None
+    match = re.search(r"\d+(?:\.\d+)?", text)
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _parse_bed_bath(text: Optional[str]) -> Tuple[Optional[float], Optional[float]]:
+    if not text:
+        return None, None
+
+    bedrooms: Optional[float] = None
+    bathrooms: Optional[float] = None
+
+    segments = [seg.strip() for seg in re.split(r"[/|\n]", text) if seg.strip()]
+    for segment in segments:
+        lowered = segment.lower()
+        if "studio" in lowered:
+            bedrooms = 0.0
+            continue
+
+        value = _clean_float(segment)
+        if value is None:
+            continue
+
+        if any(token in lowered for token in ("bed", "bd", "br")):
+            bedrooms = value
+        elif any(token in lowered for token in ("bath", "ba")):
+            bathrooms = value
+        elif bedrooms is None:
+            bedrooms = value
+        elif bathrooms is None:
+            bathrooms = value
+
+    return bedrooms, bathrooms
+
+
+def _extract_rent(container: BeautifulSoup) -> Optional[int]:
+    rent_el = container.select_one(".js-listing-blurb-rent")
+    if rent_el:
+        return _clean_price(rent_el.get_text(" ", strip=True))
+
+    for item in container.select(".detail-box__item"):
+        label = item.select_one(".detail-box__label")
+        if label and "rent" in label.get_text(strip=True).lower():
+            value_el = item.select_one(".detail-box__value")
+            if value_el:
+                return _clean_price(value_el.get_text(" ", strip=True))
+    return None
+
+
+def _extract_beds_baths(container: BeautifulSoup) -> Tuple[Optional[float], Optional[float]]:
+    text_el = container.select_one(".js-listing-blurb-bed-bath")
+    if text_el:
+        return _parse_bed_bath(text_el.get_text(" ", strip=True))
+
+    for item in container.select(".detail-box__item"):
+        label = item.select_one(".detail-box__label")
+        if label and "bed" in label.get_text(strip=True).lower():
+            value_el = item.select_one(".detail-box__value")
+            if value_el:
+                return _parse_bed_bath(value_el.get_text(" ", strip=True))
+
+    return None, None
+
+
+def _parse_listing(container: BeautifulSoup, base_url: str) -> Optional[Unit]:
+    link = container.select_one("a[href*='/listings/detail']") or container.select_one("a[href]")
+    href = link.get("href") if link else None
+    source_url = urljoin(base_url, href) if href else base_url
+
+    address: Optional[str] = None
+    for selector in (
+        ".js-listing-address",
+        ".listing-item__address",
+        ".listing-item__title a",
+        ".listing-item__title",
+    ):
+        address_el = container.select_one(selector)
+        if address_el and address_el.get_text(strip=True):
+            address = address_el.get_text(strip=True)
+            break
+
+    rent = _extract_rent(container)
+    bedrooms, bathrooms = _extract_beds_baths(container)
+
+    if not address and not source_url:
+        return None
+
+    return Unit(
+        address=address,
+        bedrooms=bedrooms,
+        bathrooms=bathrooms,
+        rent=rent,
+        neighborhood=None,
+        source_url=source_url,
+    )
+
+
+def parse_listings(html: str, *, base_url: str = LISTINGS_URL) -> List[Unit]:
+    soup = BeautifulSoup(html, "lxml")
+
+    units: List[Unit] = []
+    for container in soup.select("div.listing-item"):
+        unit = _parse_listing(container, base_url=base_url)
+        if unit:
+            units.append(unit)
+    return units
+
+
+def fetch_units(url: str = LISTINGS_URL, *, timeout: int = 20) -> List[Unit]:
+    response = requests.get(url, headers=HEADERS, timeout=timeout)
+    response.raise_for_status()
+    return parse_listings(response.text, base_url=url)
+
+
+fetch_units.default_url = LISTINGS_URL  # type: ignore[attr-defined]
+
+
+__all__ = ["fetch_units", "parse_listings"]

--- a/parser/tests/test_anchorealty_scraper.py
+++ b/parser/tests/test_anchorealty_scraper.py
@@ -1,0 +1,72 @@
+"""Tests for the Anchor Realty scraper."""
+
+from parser.scrapers.anchorealty_scraper import LISTINGS_URL, parse_listings
+
+
+def test_parse_listings_extracts_core_fields():
+    html = """
+    <div class="listing-item" id="listing_514">
+        <div class="listing-item__figure-container">
+            <a href="/listings/detail/fc8f831b-268d-4da3-99ba-a669670d39b7">
+                <div class="listing-item__figure">
+                    <div class="listing-item__blurb">
+                        <div class="rent-banner__text js-listing-blurb-rent">$2,595</div>
+                        <span class="rent-banner__text js-listing-blurb-bed-bath">Studio / 1 ba</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="listing-item__body">
+            <h2 class="listing-item__title">
+                <a href="/listings/detail/fc8f831b-268d-4da3-99ba-a669670d39b7">
+                    Renovated Nob Hill Studio with In Unit Laundry!
+                </a>
+            </h2>
+            <p>
+                <span class="u-pad-rm js-listing-address">
+                    1684 Washington Street #2, San Francisco, CA 94109
+                </span>
+            </p>
+        </div>
+    </div>
+    """
+
+    units = parse_listings(html, base_url=LISTINGS_URL)
+    assert len(units) == 1
+
+    unit = units[0]
+    assert unit.address == "1684 Washington Street #2, San Francisco, CA 94109"
+    assert unit.rent == 2595
+    assert unit.bedrooms == 0
+    assert unit.bathrooms == 1
+    assert unit.source_url == (
+        "https://anchorealtyinc.com/listings/detail/"
+        "fc8f831b-268d-4da3-99ba-a669670d39b7"
+    )
+
+
+def test_parse_listings_handles_missing_values():
+    html = """
+    <div>
+        <div class="listing-item">
+            <div class="listing-item__body">
+                <span class="js-listing-address">1200 Pine St</span>
+            </div>
+        </div>
+        <div class="listing-item">
+            <a href="/listings/detail/abc"></a>
+        </div>
+    </div>
+    """
+
+    units = parse_listings(html, base_url=LISTINGS_URL)
+    assert len(units) == 2
+
+    first, second = units
+    assert first.address == "1200 Pine St"
+    assert first.rent is None
+    assert first.bedrooms is None
+    assert first.bathrooms is None
+
+    assert second.address is None
+    assert second.source_url == "https://anchorealtyinc.com/listings/detail/abc"


### PR DESCRIPTION
## Summary
- add a scraper for Anchor Realty residential rentals including rent and bed/bath parsing helpers
- register the new scraper in the default registry
- add unit tests that cover core parsing behaviour and missing data cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddfc8e2cc48330b4d19dbb40e7aecb