### PR TITLE
Add RentBT scraper

### DIFF
--- a/parser/scrapers/__init__.py
+++ b/parser/scrapers/__init__.py
@@ -34,6 +34,13 @@ def _load_default_scrapers() -> Dict[str, ScraperFunc]:
     else:
         registry["chandlerproperties"] = chandler_fetch
 
+    try:
+        from .rentbt_scraper import fetch_units as rentbt_fetch
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        missing.append(getattr(exc, "name", "rentbt_scraper dependency"))
+    else:
+        registry["rentbt"] = rentbt_fetch
+
     if not registry and missing:
         details = ", ".join(sorted(set(filter(None, missing))))
         raise RuntimeError(

--- a/parser/scrapers/rentbt_scraper.py
+++ b/parser/scrapers/rentbt_scraper.py
@@ -1,0 +1,190 @@
+"""Scraper for RentBT (rentbt.com) property listings."""
+
+from __future__ import annotations
+
+import time
+from typing import List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from parser.heuristics import money_to_int, parse_bathrooms, parse_bedrooms
+from parser.models import Unit
+
+BASE_URL = (
+    "https://properties.rentbt.com/searchlisting.aspx?ftst=&txtCity=san%20francisco"
+    "&txtMinRent=3000&txtMaxRent=4000&cmbBeds=2&txtDistance=2&LocationGeoId=0"
+    "&zoom=10&autoCompleteCorpPropSearchlen=3&renewpg=1&PgNo=1"
+    "&LatLng=(37.7749295,-122.4194155)&"
+)
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+}
+
+
+def _clean_rent(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    text = value.strip().replace(",", "")
+    if not text:
+        return None
+    try:
+        return int(float(text))
+    except ValueError:
+        return None
+
+
+def set_page_number(url: str, page: int) -> str:
+    from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    if page <= 1:
+        query.pop("PgNo", None)
+    else:
+        query["PgNo"] = [str(page)]
+    new_query = urlencode(query, doseq=True)
+    return urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path, parsed.params, new_query, parsed.fragment)
+    )
+
+
+def _get_page(url: str, session: requests.Session, timeout: int = 20) -> str:
+    response = session.get(url, headers=HEADERS, timeout=timeout)
+    response.raise_for_status()
+    return response.text
+
+
+def _parse_address(listing: BeautifulSoup) -> Optional[str]:
+    hidden = listing.select_one(".parameters .propertyAddress")
+    if hidden and hidden.get_text(strip=True):
+        return " ".join(hidden.get_text(strip=True).split())
+
+    parts: List[str] = []
+    for selector in (".propertyAddress", ".propertyCity", ".propertyState", ".propertyZipCode"):
+        element = listing.select_one(f".prop-address {selector}")
+        if element and element.get_text(strip=True):
+            parts.append(" ".join(element.get_text(strip=True).split()))
+    if parts:
+        return " ".join(parts)
+    return None
+
+
+def _parse_bedrooms(listing: BeautifulSoup) -> Optional[float]:
+    for selector in (".propertyMaxBed", ".propertyMinBed"):
+        element = listing.select_one(selector)
+        if element and element.get_text(strip=True):
+            beds = parse_bedrooms(f"{element.get_text(strip=True)} bed")
+            if beds is not None:
+                return beds
+
+    beds_el = listing.select_one(".prop-beds")
+    if beds_el and beds_el.get_text(strip=True):
+        beds = parse_bedrooms(beds_el.get_text(" ", strip=True))
+        if beds is not None:
+            return beds
+
+    return None
+
+
+def _parse_bathrooms(listing: BeautifulSoup) -> Optional[float]:
+    baths_el = listing.select_one(".prop-baths")
+    if baths_el and baths_el.get_text(strip=True):
+        baths = parse_bathrooms(baths_el.get_text(" ", strip=True))
+        if baths is not None:
+            return baths
+
+    element = listing.select_one(".propertyMinBath")
+    if element and element.get_text(strip=True):
+        return parse_bathrooms(f"{element.get_text(strip=True)} bath")
+    return None
+
+
+def _parse_rent(listing: BeautifulSoup) -> Optional[int]:
+    hidden = listing.select_one(".parameters .propertyMinRent")
+    if hidden and hidden.get_text(strip=True):
+        rent = _clean_rent(hidden.get_text(strip=True))
+        if rent is not None:
+            return rent
+
+    display = listing.select_one(".prop-rent")
+    if display and display.get_text(strip=True):
+        rent = money_to_int(display.get_text(" ", strip=True))
+        if rent is not None:
+            return rent
+
+    element = listing.select_one(".propertyMaxRent")
+    if element and element.get_text(strip=True):
+        return _clean_rent(element.get_text(strip=True))
+    return None
+
+
+def parse_listings(html: str, *, base_url: str = BASE_URL) -> List[Unit]:
+    soup = BeautifulSoup(html, "lxml")
+    listings: List[Unit] = []
+
+    for container in soup.select("div.property-details.prop-listing-box"):
+        address = _parse_address(container)
+        rent = _parse_rent(container)
+        bedrooms = _parse_bedrooms(container)
+        bathrooms = _parse_bathrooms(container)
+
+        anchor = container.select_one("a.propertyUrl")
+        href = anchor.get("href") if anchor else None
+        url = requests.compat.urljoin(base_url, href) if href else base_url
+
+        if not (address or rent or href):
+            continue
+
+        listings.append(
+            Unit(
+                address=address,
+                bedrooms=bedrooms,
+                bathrooms=bathrooms,
+                rent=rent,
+                neighborhood=None,
+                source_url=url,
+            )
+        )
+
+    return listings
+
+
+def fetch_units(
+    url: str = BASE_URL,
+    *,
+    pages: int = 1,
+    delay: float = 1.0,
+    session: Optional[requests.Session] = None,
+    timeout: int = 20,
+) -> List[Unit]:
+    """Fetch RentBT listings from *url*, iterating pagination up to *pages*."""
+
+    http_session = session or requests.Session()
+    all_units: List[Unit] = []
+
+    for page in range(1, max(1, pages) + 1):
+        page_url = set_page_number(url, page)
+        html = _get_page(page_url, session=http_session, timeout=timeout)
+        units = parse_listings(html, base_url=url)
+        if not units and page > 1:
+            break
+        all_units.extend(units)
+        if delay:
+            time.sleep(delay)
+
+    return all_units
+
+
+fetch_units.default_url = BASE_URL  # type: ignore[attr-defined]
+
+
+__all__ = ["fetch_units", "parse_listings", "set_page_number"]

--- a/parser/tests/test_rentbt_scraper.py
+++ b/parser/tests/test_rentbt_scraper.py
@@ -1,0 +1,57 @@
+"""Tests for the RentBT scraper."""
+
+from __future__ import annotations
+
+import textwrap
+
+from parser.scrapers.rentbt_scraper import parse_listings, set_page_number
+
+
+def test_parse_listings_extracts_key_fields():
+    html = textwrap.dedent(
+        """
+        <div class="property-details prop-listing-box">
+          <div class="parameters hidden mapPoint">
+            <span class="propertyAddress">1395 Golden Gate Avenue San Francisco CA 94115</span>
+            <span class="propertyMinRent">3445.00</span>
+          </div>
+          <div class="prop-address">
+            <span class="propertyAddress">1395 Golden Gate Avenue</span>
+            <span class="propertyCity">San Francisco</span>
+            <span class="propertyState">CA</span>
+            <span class="propertyZipCode">94115</span>
+          </div>
+          <div class="display-icons">
+            <ul>
+              <li class="prop-rent">$<span class="propertyMaxRent">3445</span></li>
+              <li class="prop-beds"><span class="propertyMinBed">Studio</span> - <span class="propertyMaxBed">2</span></li>
+              <li class="prop-baths"><span class="propertyMinBath">1</span></li>
+            </ul>
+          </div>
+          <div class="prop-details">
+            <a class="propertyUrl" href="/apartments/ca/san-francisco/1395-golden-gate-avenue-owner-lp/default.aspx">Details</a>
+          </div>
+        </div>
+        """
+    )
+
+    units = parse_listings(html, base_url="https://properties.rentbt.com/searchlisting.aspx")
+
+    assert len(units) == 1
+    unit = units[0]
+    assert unit.address == "1395 Golden Gate Avenue San Francisco CA 94115"
+    assert unit.rent == 3445
+    assert unit.bedrooms == 2
+    assert unit.bathrooms == 1
+    assert (
+        unit.source_url
+        == "https://properties.rentbt.com/apartments/ca/san-francisco/1395-golden-gate-avenue-owner-lp/default.aspx"
+    )
+
+
+def test_set_page_number_updates_querystring():
+    base = "https://properties.rentbt.com/searchlisting.aspx?PgNo=1&txtCity=san%20francisco"
+    second = set_page_number(base, 2)
+    assert "PgNo=2" in second
+    first = set_page_number(second, 1)
+    assert "PgNo=" not in first


### PR DESCRIPTION
## Summary
- add a scraper for RentBT listings including pagination support
- register the new scraper in the default registry
- cover the parser with unit tests for listing parsing and pagination URL handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddfcad28a48330b8bcad8b3917bfe9