### PR TITLE
Improve scraper debugging and logging

### DIFF
--- a/parser/cli.py
+++ b/parser/cli.py
@@ -77,16 +77,22 @@ def main(argv: List[str] | None = None) -> int:
 
         for site_result in result.site_results:
             if site_result.error is None:
-                total_extracted = len(site_result.units) + len(site_result.error.units) if site_result.error else len(site_result.units)
-                # If you want the raw extracted count, you need to get it before filtering.
-                # But in your workflow, only filtered units are stored.
-                # So, you need to modify workflow.py to return both extracted and filtered counts.
+                total_extracted = getattr(site_result, "total_extracted", None)
+                if total_extracted is None:
+                    total_extracted = len(site_result.units)
+
                 logging.info(
                     "Site: %s\n  Extracted: %d unit(s)\n  Matching criteria: %d unit(s)",
                     site_result.site.url or site_result.site.slug,
-                    getattr(site_result, "total_extracted", len(site_result.units)),  # fallback to filtered if not available
+                    total_extracted,
                     len(site_result.units),
                 )
+
+                if total_extracted == 0:
+                    logging.debug(
+                        "No listing containers matched for site '%s'. See scraper debug logs for selector details.",
+                        site_result.site.slug,
+                    )
             else:
                 logging.error(
                     "Failed to process %s: %s",

--- a/parser/scrapers/chandlerproperties_scraper.py
+++ b/parser/scrapers/chandlerproperties_scraper.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 import re
-from typing import List, Optional
+from typing import Any, List, Optional
 from urllib.parse import urljoin
 
-import httpx
+import requests
 from bs4 import BeautifulSoup
 
 from parser.models import Unit
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    import httpx  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback path
+    httpx = None  # type: ignore
 
 LISTINGS_URL = "https://chandlerproperties.com/rental-listings/"
 
@@ -26,29 +34,52 @@ HEADERS = {
     "Accept-Encoding": "gzip, deflate, br",
 }
 
-def get_html(url: str, client: httpx.Client, referer: Optional[str] = None) -> str:
+
+def get_html(url: str, client: Any, referer: Optional[str] = None) -> str:
+    """Fetch *url* with retry logic and optional *referer* header."""
+
     headers = HEADERS.copy()
     if referer:
         headers["Referer"] = referer
-    # Optionally, you can set cookies here if needed
+
+    logger.debug("Chandler Properties request %s (referer=%s)", url, referer)
+
     for attempt in range(3):
-        r = client.get(url, headers=headers, timeout=httpx.Timeout(20.0))
-        if r.status_code == 200:
-            # Save cookies for subsequent requests
-            if r.cookies:
-                client.cookies.update(r.cookies)
-            return r.text
-        if r.status_code in (403, 429, 503):
-            import time, random
+        timeout = httpx.Timeout(20.0) if httpx else 20.0  # type: ignore[union-attr]
+        response = client.get(url, headers=headers, timeout=timeout)
+        if response.status_code == 200:
+            if response.cookies:
+                client.cookies.update(response.cookies)
+            logger.debug(
+                "Chandler Properties HTTP %s on attempt %d (%d bytes)",
+                response.status_code,
+                attempt + 1,
+                len(response.content),
+            )
+            return response.text
+
+        if response.status_code in (403, 429, 503):
+            import random
+            import time
+
             time.sleep(1.0 + attempt + random.uniform(0, 0.5))
             continue
-        r.raise_for_status()
-    # final try or raise
-    r = client.get(url, headers=headers, timeout=httpx.Timeout(20.0))
-    r.raise_for_status()
-    if r.cookies:
-        client.cookies.update(r.cookies)
-    return r.text
+
+        response.raise_for_status()
+
+    # Final attempt will either succeed or raise.
+    timeout = httpx.Timeout(20.0) if httpx else 20.0  # type: ignore[union-attr]
+    response = client.get(url, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    logger.debug(
+        "Chandler Properties final retry HTTP %s (%d bytes)",
+        response.status_code,
+        len(response.content),
+    )
+    if response.cookies:
+        client.cookies.update(response.cookies)
+    return response.text
+
 
 def _clean_price(text: Optional[str]) -> Optional[int]:
     if not text:
@@ -62,6 +93,7 @@ def _clean_price(text: Optional[str]) -> Optional[int]:
     except ValueError:
         return None
 
+
 def _clean_float(text: Optional[str]) -> Optional[float]:
     if not text:
         return None
@@ -72,6 +104,7 @@ def _clean_float(text: Optional[str]) -> Optional[float]:
         return float(match.group(0))
     except ValueError:
         return None
+
 
 def _parse_listing(container: BeautifulSoup, base_url: str) -> Optional[Unit]:
     anchor = container.select_one("a[href]")
@@ -102,24 +135,57 @@ def _parse_listing(container: BeautifulSoup, base_url: str) -> Optional[Unit]:
         source_url=source_url,
     )
 
+
 def parse_listings(html: str, *, base_url: str = LISTINGS_URL) -> List[Unit]:
     soup = BeautifulSoup(html, "lxml")
 
+    containers = soup.select("div.listing-item")
+    logger.debug("Chandler Properties parser located %d potential listing containers", len(containers))
+
     units: List[Unit] = []
-    for container in soup.select("div.listing-item"):
+    for idx, container in enumerate(containers):
         unit = _parse_listing(container, base_url=base_url)
         if unit:
+            if idx < 3:
+                logger.debug(
+                    "Chandler Properties sample listing %d: address=%s rent=%s bedrooms=%s",
+                    idx,
+                    unit.address,
+                    unit.rent,
+                    unit.bedrooms,
+                )
             units.append(unit)
+
     return units
 
-def fetch_units(url: str = LISTINGS_URL, *, timeout: int = 20) -> List[Unit]:
-    client = httpx.Client(http2=True, follow_redirects=True, headers=HEADERS)
-    # Warm up: initial request to set cookies
-    landing_html = get_html(LISTINGS_URL, client)
-    # Main request with referer and cookies
-    html = get_html(url, client, referer=LISTINGS_URL if url != LISTINGS_URL else None)
-    return parse_listings(html, base_url=url)
 
-fetch_units.default_url = LISTINGS_URL  # Add this line after defining fetch_units
+def fetch_units(url: str = LISTINGS_URL, *, timeout: int = 20) -> List[Unit]:
+    if httpx is not None:
+        client = httpx.Client(
+            http2=True,
+            follow_redirects=True,
+            headers=HEADERS,
+            timeout=httpx.Timeout(timeout),
+        )
+        close_client = client.close
+    else:  # pragma: no cover - fallback path
+        client = requests.Session()
+        client.headers.update(HEADERS)
+        close_client = client.close
+
+    try:
+        # Warm up: initial request to set cookies
+        landing_html = get_html(LISTINGS_URL, client)
+        logger.debug("Chandler Properties warm-up fetched %d bytes", len(landing_html))
+
+        # Main request with referer and cookies
+        referer = LISTINGS_URL if url != LISTINGS_URL else None
+        html = get_html(url, client, referer=referer)
+        return parse_listings(html, base_url=url)
+    finally:
+        close_client()
+
+
+fetch_units.default_url = LISTINGS_URL  # type: ignore[attr-defined]
 
 __all__ = ["fetch_units", "parse_listings"]


### PR DESCRIPTION
## Summary
- add structured debug logging across the AMS IRES, Anchor Realty, Chandler Properties, and Structure Properties scrapers to surface container counts and sample listings
- improve workflow reporting to capture raw extraction counts, log scraper execution details, and avoid invalid total calculations when reporting CLI output
- harden the Chandler Properties and Structure Properties scrapers to operate without httpx while still emitting detailed request diagnostics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de05898f1c8330a86ae314cf522ef3