### PR TITLE
Update AMS IRES scraper to use API endpoint

### DIFF
--- a/parser/scrapers/amsires_scraper.py
+++ b/parser/scrapers/amsires_scraper.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import re
+import html
+import json
 import logging
-from typing import List, Optional
-from urllib.parse import urljoin
+import re
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, cast
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 
 import requests
 from bs4 import BeautifulSoup
@@ -17,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 SEARCH_URL = "https://www.amsires.com/unfurnished-rentals-search"
 
-HEADERS = {
+HTML_HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -28,11 +30,285 @@ HEADERS = {
     "Connection": "keep-alive",
 }
 
+JSON_HEADERS = dict(HTML_HEADERS)
+JSON_HEADERS["Accept"] = "application/json, text/plain;q=0.9,*/*;q=0.8"
+
+def _iter_pairs(obj: Any, *, _seen: Optional[set[int]] = None) -> Iterable[Tuple[str, Any]]:
+    if _seen is None:
+        _seen = set()
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return
+    _seen.add(obj_id)
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            yield key.lower(), value
+            yield from _iter_pairs(value, _seen=_seen)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_pairs(item, _seen=_seen)
+
+
+def _normalise_value(value: Any, *, _seen: Optional[set[int]] = None) -> Optional[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, (int, float)):
+        return str(value)
+    if _seen is None:
+        _seen = set()
+    value_id = id(value)
+    if value_id in _seen:
+        return None
+    _seen.add(value_id)
+    if isinstance(value, dict):
+        for key in ("value", "displayvalue", "display", "rawvalue", "text", "label", "values"):
+            if key in value:
+                candidate = _normalise_value(value[key], _seen=_seen)
+                if candidate:
+                    return candidate
+        for sub in value.values():
+            candidate = _normalise_value(sub, _seen=_seen)
+            if candidate:
+                return candidate
+    elif isinstance(value, list):
+        for item in value:
+            candidate = _normalise_value(item, _seen=_seen)
+            if candidate:
+                return candidate
+    return None
+
+
+def _extract_field(data: Dict[str, Any], keys: Sequence[str]) -> Optional[str]:
+    lookup = {key.lower() for key in keys}
+    for key, value in _iter_pairs(data):
+        if key in lookup:
+            normalised = _normalise_value(value)
+            if normalised:
+                return normalised
+    return None
+
+
+def _normalise_url(candidate: str, *, base_url: str) -> Optional[str]:
+    if not candidate:
+        return None
+    candidate = candidate.strip()
+    if not candidate or candidate.lower().startswith("javascript:"):
+        return None
+    if candidate.startswith("//"):
+        candidate = "https:" + candidate
+    url = urljoin(base_url, candidate)
+    lowered = url.lower()
+    if any(lowered.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif", ".svg", ".webp")):
+        return None
+    return url
+
+
+def _extract_url(data: Dict[str, Any], *, base_url: str) -> Optional[str]:
+    preferred_keys = (
+        "url",
+        "href",
+        "link",
+        "detailurl",
+        "permalink",
+        "website",
+        "listingurl",
+        "appfoliolistingurl",
+        "toururl",
+    )
+    for key in preferred_keys:
+        value = _extract_field(data, (key,))
+        if value:
+            url = _normalise_url(value, base_url=base_url)
+            if url:
+                return url
+
+    for _, value in _iter_pairs(data):
+        candidate = _normalise_value(value)
+        if not candidate or not isinstance(candidate, str):
+            continue
+        url = _normalise_url(candidate, base_url=base_url)
+        if not url:
+            continue
+        if "appfolio" in url or "amsires" in url:
+            return url
+        if not any(url.lower().endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif", ".svg", ".webp")):
+            return url
+    return None
+
+
+def _parse_json_listing(item: Dict[str, Any], *, base_url: str) -> Optional[Unit]:
+    address = _extract_field(item, ("address", "streetaddress", "address1", "addressline1", "propertyaddress", "location"))
+    rent_value = None
+    for key in ("rent", "price", "monthlyrent", "minrent", "maxrent", "baserent", "amount"):
+        rent_value = _extract_field(item, (key,))
+        rent = _clean_price(rent_value)
+        if rent is not None:
+            break
+    else:
+        rent = None
+
+    bedrooms_value = _extract_field(item, ("bedrooms", "beds", "bed"))
+    bedrooms = _clean_float(bedrooms_value) if bedrooms_value else None
+
+    bathrooms_value = _extract_field(item, ("bathrooms", "baths", "bath"))
+    bathrooms = _clean_float(bathrooms_value) if bathrooms_value else None
+
+    neighborhood = _extract_field(item, ("neighborhood", "area", "district", "community", "region"))
+
+    source_url = _extract_url(item, base_url=base_url)
+
+    if not address and not source_url:
+        return None
+
+    return Unit(
+        address=address,
+        bedrooms=bedrooms,
+        bathrooms=bathrooms,
+        rent=rent,
+        neighborhood=neighborhood,
+        source_url=source_url or base_url,
+    )
+
+
+def parse_appfolio_json(data: Any, *, base_url: str) -> List[Unit]:
+    candidates: List[List[Dict[str, Any]]] = []
+
+    def _collect(obj: Any) -> None:
+        if isinstance(obj, list):
+            if obj and all(isinstance(entry, dict) for entry in obj):
+                candidates.append(cast(List[Dict[str, Any]], obj))
+            for item in obj:
+                _collect(item)
+        elif isinstance(obj, dict):
+            for value in obj.values():
+                _collect(value)
+
+    _collect(data)
+
+    units: List[Unit] = []
+    seen: set[Tuple[Optional[str], Optional[str]]] = set()
+    for candidate in candidates:
+        for entry in candidate:
+            unit = _parse_json_listing(entry, base_url=base_url)
+            if not unit:
+                continue
+            key = (unit.source_url, unit.address)
+            if key in seen:
+                continue
+            seen.add(key)
+            units.append(unit)
+    return units
+
+
+def _find_api_url(html_text: str, *, base_url: str) -> Optional[str]:
+    # First look for a fully qualified URL including query parameters.
+    url_match = re.search(r"((?:https?:)?//[^'\"\s]+appfolio-listings/data)", html_text, re.IGNORECASE)
+    candidate: Optional[str] = None
+    if url_match:
+        candidate = html.unescape(url_match.group(1))
+    else:
+        path_match = re.search(
+            r"(/rts/collections/public/[0-9a-z-]+/runtime/collection/appfolio-listings/data)",
+            html_text,
+            re.IGNORECASE,
+        )
+        if path_match:
+            candidate = urljoin(base_url, html.unescape(path_match.group(1)))
+
+    if not candidate:
+        return None
+
+    candidate = candidate.replace("\\/", "/")
+    parsed = urlsplit(candidate)
+    query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    query: Dict[str, str] = {key: value for key, value in query_items}
+
+    if "page" not in query:
+        query["page"] = json.dumps({"pageSize": 100, "pageNumber": 0}, separators=(",", ":"))
+    if "language" not in query:
+        query["language"] = "ENGLISH"
+
+    new_query = urlencode(query, doseq=True)
+    rebuilt = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, new_query, parsed.fragment))
+    if not rebuilt.startswith("http"):
+        return urljoin(base_url, rebuilt)
+    return rebuilt
+    return None
+
+
+def _next_page_url(url: str, *, page_number: int) -> Optional[str]:
+    parsed = urlsplit(url)
+    query_items = parse_qsl(parsed.query, keep_blank_values=True)
+    query_dict = dict(query_items)
+    if "page" not in query_dict:
+        return None
+    try:
+        page_payload = json.loads(query_dict["page"])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(page_payload, dict):
+        return None
+    page_payload["pageNumber"] = page_number
+    if "pageSize" not in page_payload:
+        page_payload["pageSize"] = 100
+    query_dict["page"] = json.dumps(page_payload, separators=(",", ":"))
+    new_query = urlencode(query_dict, doseq=True)
+    new_parts = (
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+        new_query,
+        parsed.fragment,
+    )
+    return urlunsplit(new_parts)
+
+
+def _extract_pagination(data: Any) -> Optional[Tuple[int, int]]:
+    for obj in _iter_dicts(data):
+        page_number: Optional[Any] = None
+        for key in ("pageNumber", "pagenumber", "currentPage", "currentpage"):
+            if key in obj and obj[key] is not None:
+                page_number = obj[key]
+                break
+
+        total_pages: Optional[Any] = None
+        for key in ("totalPages", "totalpages"):
+            if key in obj and obj[key] is not None:
+                total_pages = obj[key]
+                break
+
+        if page_number is None or total_pages is None:
+            continue
+        try:
+            current = int(float(page_number))
+            total = int(float(total_pages))
+        except (TypeError, ValueError):
+            continue
+        return current, total
+    return None
+
+
+def _iter_dicts(obj: Any, *, _seen: Optional[set[int]] = None) -> Iterable[Dict[str, Any]]:
+    if _seen is None:
+        _seen = set()
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return
+    _seen.add(obj_id)
+    if isinstance(obj, dict):
+        yield obj
+        for value in obj.values():
+            yield from _iter_dicts(value, _seen=_seen)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_dicts(item, _seen=_seen)
+
 
 def _clean_price(text: Optional[str]) -> Optional[int]:
     if not text:
         return None
-    m = re.search(r"[\\$\\s]*([\\d,]+(?:\\.\\d+)?)", text)
+    m = re.search(r"[\$\s]*([\d,]+(?:\.\d+)?)", text)
     if not m:
         return None
     num = m.group(1).replace(",", "")
@@ -44,7 +320,7 @@ def _clean_price(text: Optional[str]) -> Optional[int]:
 def _clean_float(text: Optional[str]) -> Optional[float]:
     if not text:
         return None
-    m = re.search(r"\\d+(?:\\.\\d+)?", text)
+    m = re.search(r"\d+(?:\.\d+)?", text)
     if not m:
         return None
     try:
@@ -128,17 +404,73 @@ def parse_listings(html: str, *, base_url: str) -> List[Unit]:
     return units
 
 
+def _fetch_api_units(api_url: str, *, base_url: str, timeout: int) -> List[Unit]:
+    logger.debug("Fetching AMS IRES API data from %s", api_url)
+    units: List[Unit] = []
+    seen: set[Tuple[Optional[str], Optional[str]]] = set()
+    next_url = api_url
+    visited: set[str] = set()
+
+    while next_url and next_url not in visited:
+        visited.add(next_url)
+        response = requests.get(next_url, headers=JSON_HEADERS, timeout=timeout)
+        response.raise_for_status()
+        try:
+            payload = response.json()
+        except ValueError as exc:  # pragma: no cover - defensive
+            logger.warning("AMS IRES API returned non-JSON payload: %s", exc)
+            break
+
+        page_units = parse_appfolio_json(payload, base_url=base_url)
+        for unit in page_units:
+            key = (unit.source_url, unit.address)
+            if key in seen:
+                continue
+            seen.add(key)
+            units.append(unit)
+
+        pagination = _extract_pagination(payload)
+        if not pagination:
+            break
+        current_page, total_pages = pagination
+        if current_page + 1 >= total_pages:
+            break
+        candidate = _next_page_url(next_url, page_number=current_page + 1)
+        if not candidate:
+            break
+        next_url = candidate
+
+    return units
+
+
 def fetch_units(url: str = SEARCH_URL, *, timeout: int = 20) -> List[Unit]:
     """Fetch and parse AMS IRES listings from *url*."""
 
     logger.debug("Fetching AMS IRES listings from %s", url)
-    response = requests.get(url, headers=HEADERS, timeout=timeout)
+
+    if "appfolio-listings/data" in url:
+        return _fetch_api_units(url, base_url=url, timeout=timeout)
+
+    response = requests.get(url, headers=HTML_HEADERS, timeout=timeout)
     response.raise_for_status()
     logger.debug("AMS IRES HTTP %s (%d bytes)", response.status_code, len(response.content))
-    return parse_listings(response.text, base_url=url)
+
+    html_text = response.text
+    units = parse_listings(html_text, base_url=url)
+    if units:
+        return units
+
+    api_url = _find_api_url(html_text, base_url=url)
+    if not api_url:
+        logger.debug("AMS IRES HTML parser produced no units and no API endpoint was discovered")
+        return units
+
+    logger.debug("AMS IRES falling back to AppFolio API endpoint %s", api_url)
+    api_units = _fetch_api_units(api_url, base_url=url, timeout=timeout)
+    return api_units or units
 
 
 fetch_units.default_url = SEARCH_URL  # type: ignore[attr-defined]
 
 
-__all__ = ["fetch_units", "parse_listings"]
+__all__ = ["fetch_units", "parse_listings", "parse_appfolio_json"]

--- a/parser/tests/test_amsires_scraper.py
+++ b/parser/tests/test_amsires_scraper.py
@@ -1,0 +1,223 @@
+import json
+from typing import Any, Dict, List
+
+import pytest
+import requests
+
+from parser.scrapers.amsires_scraper import (
+    SEARCH_URL,
+    fetch_units,
+    parse_appfolio_json,
+)
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        *,
+        url: str,
+        text: str,
+        headers: Dict[str, str] | None = None,
+        status_code: int = 200,
+        json_data: Any | None = None,
+    ) -> None:
+        self.url = url
+        self.text = text
+        self.headers = headers or {}
+        self.status_code = status_code
+        self._json_data = json_data
+        self.content = text.encode("utf-8")
+
+    def raise_for_status(self) -> None:
+        if 400 <= self.status_code:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+    def json(self) -> Any:
+        if self._json_data is None:
+            raise ValueError("no json data")
+        return self._json_data
+
+
+def test_parse_appfolio_json_extracts_units() -> None:
+    api_data = {
+        "data": {
+            "items": [
+                {
+                    "attributes": {
+                        "address": {"value": "123 Main St"},
+                        "beds": {"value": "2"},
+                        "baths": {"value": "1"},
+                        "rent": {"value": "$2,500"},
+                        "neighborhood": {"value": "SOMA"},
+                        "listingUrl": {"value": "https://amsires.appfolio.com/listings/detail/unit-1"},
+                    }
+                },
+                {
+                    "attributes": {
+                        "location": {"text": "456 Market St"},
+                        "bedrooms": {"values": ["3"]},
+                        "bathrooms": {"value": 2},
+                        "price": {"rawValue": "3450"},
+                        "website": {"value": "/vacancies/unit-2"},
+                    }
+                },
+            ]
+        }
+    }
+
+    units = parse_appfolio_json(api_data, base_url=SEARCH_URL)
+    assert len(units) == 2
+
+    first, second = units
+    assert first.address == "123 Main St"
+    assert first.rent == 2500
+    assert first.source_url == "https://amsires.appfolio.com/listings/detail/unit-1"
+    assert pytest.approx(first.bedrooms) == 2
+    assert pytest.approx(first.bathrooms) == 1
+    assert first.neighborhood == "SOMA"
+
+    assert second.address == "456 Market St"
+    assert second.rent == 3450
+    assert second.source_url == "https://www.amsires.com/vacancies/unit-2"
+    assert pytest.approx(second.bedrooms or 0) == 3
+    assert pytest.approx(second.bathrooms or 0) == 2
+
+
+def test_fetch_units_falls_back_to_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    api_url = (
+        "https://www.amsires.com/rts/collections/public/test/runtime/collection/"
+        "appfolio-listings/data?page=%7B%22pageSize%22%3A100%2C%22pageNumber%22%3A0%7D&language=ENGLISH"
+    )
+
+    html = (
+        '<html><head></head><body>'
+        f'<script>fetch("{api_url}")</script>'
+        '</body></html>'
+    )
+
+    api_payload = {
+        "data": {
+            "items": [
+                {
+                    "attributes": {
+                        "location": {"value": "789 Mission St"},
+                        "beds": {"value": "1"},
+                        "baths": {"value": "1"},
+                        "rent": {"value": "$3,000"},
+                        "listingUrl": {"value": "https://amsires.appfolio.com/listings/detail/unit-3"},
+                    }
+                }
+            ]
+        },
+        "page": {"pageNumber": 0, "totalPages": 1},
+    }
+
+    responses: List[DummyResponse] = [
+        DummyResponse(url=SEARCH_URL, text=html, headers={"Content-Type": "text/html"}),
+        DummyResponse(
+            url=api_url,
+            text=json.dumps(api_payload),
+            headers={"Content-Type": "application/json"},
+            json_data=api_payload,
+        ),
+    ]
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: int) -> DummyResponse:
+        assert responses, "unexpected extra HTTP call"
+        response = responses.pop(0)
+        assert response.url == url
+        if "appfolio-listings" in url:
+            assert "application/json" in headers.get("Accept", "")
+        else:
+            assert "text/html" in headers.get("Accept", "")
+        assert timeout == 5
+        return response
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    units = fetch_units(SEARCH_URL, timeout=5)
+    assert len(units) == 1
+    assert units[0].address == "789 Mission St"
+    assert units[0].rent == 3000
+    assert units[0].source_url == "https://amsires.appfolio.com/listings/detail/unit-3"
+
+
+def test_fetch_units_handles_api_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_api = (
+        "https://www.amsires.com/rts/collections/public/test/runtime/collection/"
+        "appfolio-listings/data?page=%7B%22pageSize%22%3A100%2C%22pageNumber%22%3A0%7D&language=ENGLISH"
+    )
+
+    html = (
+        '<html><body><script>'
+        f'const endpoint = "{base_api}";'
+        "</script></body></html>"
+    )
+
+    page0 = {
+        "data": {
+            "items": [
+                {
+                    "attributes": {
+                        "address": {"value": "Unit 1"},
+                        "beds": {"value": "1"},
+                        "baths": {"value": "1"},
+                        "price": {"value": "$2000"},
+                        "listingUrl": {"value": "https://amsires.appfolio.com/listings/detail/unit-1"},
+                    }
+                }
+            ]
+        },
+        "page": {"pageNumber": 0, "totalPages": 2},
+    }
+
+    page1 = {
+        "data": {
+            "items": [
+                {
+                    "attributes": {
+                        "address": {"value": "Unit 2"},
+                        "beds": {"value": "2"},
+                        "baths": {"value": "2"},
+                        "rent": {"value": "$4000"},
+                        "listingUrl": {"value": "https://amsires.appfolio.com/listings/detail/unit-2"},
+                    }
+                }
+            ]
+        },
+        "page": {"pageNumber": 1, "totalPages": 2},
+    }
+
+    encoded_next = (
+        "https://www.amsires.com/rts/collections/public/test/runtime/collection/"
+        "appfolio-listings/data?page=%7B%22pageSize%22%3A100%2C%22pageNumber%22%3A1%7D&language=ENGLISH"
+    )
+
+    responses: List[DummyResponse] = [
+        DummyResponse(url=SEARCH_URL, text=html, headers={"Content-Type": "text/html"}),
+        DummyResponse(
+            url=base_api,
+            text=json.dumps(page0),
+            headers={"Content-Type": "application/json"},
+            json_data=page0,
+        ),
+        DummyResponse(
+            url=encoded_next,
+            text=json.dumps(page1),
+            headers={"Content-Type": "application/json"},
+            json_data=page1,
+        ),
+    ]
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: int) -> DummyResponse:
+        assert responses, "unexpected extra HTTP call"
+        response = responses.pop(0)
+        assert response.url == url
+        return response
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    units = fetch_units(SEARCH_URL)
+    assert [unit.address for unit in units] == ["Unit 1", "Unit 2"]
+    assert units[0].rent == 2000
+    assert units[1].rent == 4000


### PR DESCRIPTION
## Summary
- add JSON parsing utilities for AMS IRES AppFolio data and normalise value extraction helpers
- fall back to the AppFolio JSON endpoint (with pagination support) when HTML listings are empty
- add unit tests covering JSON parsing, API fallback behaviour, and pagination handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de93df743083309361f4ac11414820