### PR TITLE
Update Anchor Realty scraper for AppFolio listings

### DIFF
--- a/parser/scrapers/anchorealty_scraper.py
+++ b/parser/scrapers/anchorealty_scraper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
@@ -15,7 +15,13 @@ from parser.models import Unit
 
 logger = logging.getLogger(__name__)
 
-LISTINGS_URL = "https://anchorealtyinc.com/residential-rentals/"
+LISTING_URLS = (
+    "https://anchorrlty.appfolio.com/listings?filters%5Border_by%5D=date_posted",
+    "https://anchordc.appfolio.com/listings?filters%5Border_by%5D=date_posted",
+)
+
+# Backwards compatibility for callers that import LISTINGS_URL.
+LISTINGS_URL = LISTING_URLS[0]
 
 HEADERS = {
     "User-Agent": (
@@ -113,25 +119,112 @@ def _extract_beds_baths(container: BeautifulSoup) -> Tuple[Optional[float], Opti
     return None, None
 
 
+def _get_first_text(container: BeautifulSoup, selectors: Tuple[str, ...]) -> Optional[str]:
+    for selector in selectors:
+        element = container.select_one(selector)
+        if element:
+            text = element.get_text(" ", strip=True)
+            if text:
+                return text
+    return None
+
+
+def _extract_address(container: BeautifulSoup) -> Optional[str]:
+    address = _get_first_text(
+        container,
+        (
+            "[data-testid='listing-card-address']",
+            "[data-testid='listingCard-address']",
+            ".listing-card__address",
+            ".listing-card__title",
+            ".property-address",
+            ".js-listing-address",
+            ".listing-item__address",
+            ".listing-item__title a",
+            ".listing-item__title",
+        ),
+    )
+
+    if not address:
+        attr_value = container.get("data-address") or container.get("data-street")
+        if isinstance(attr_value, str) and attr_value.strip():
+            address = attr_value.strip()
+
+    return address
+
+
+def _extract_rent_appfolio(container: BeautifulSoup) -> Optional[int]:
+    rent_text = _get_first_text(
+        container,
+        (
+            "[data-testid='listing-card-rent']",
+            "[data-testid='listingCard-rent']",
+            ".listing-card__rent",
+            ".listing-card__price",
+            ".property-rent",
+        ),
+    )
+
+    if rent_text:
+        cleaned = _clean_price(rent_text)
+        if cleaned is not None:
+            return cleaned
+
+    # Fallback to existing extraction for legacy markup.
+    rent = _extract_rent(container)
+    if rent is not None:
+        return rent
+
+    for text in container.stripped_strings:
+        if "$" in text:
+            cleaned = _clean_price(text)
+            if cleaned is not None:
+                return cleaned
+    return None
+
+
+def _extract_beds_baths_appfolio(container: BeautifulSoup) -> Tuple[Optional[float], Optional[float]]:
+    bed_bath_text = _get_first_text(
+        container,
+        (
+            "[data-testid='listing-card-bed-bath']",
+            "[data-testid='listingCard-bedBath']",
+            ".listing-card__bed-bath",
+            ".listing-card__details",
+            ".property-beds-baths",
+        ),
+    )
+
+    if bed_bath_text:
+        parsed = _parse_bed_bath(bed_bath_text)
+        if parsed != (None, None):
+            return parsed
+
+    parsed = _extract_beds_baths(container)
+    if parsed != (None, None):
+        return parsed
+
+    for text in container.stripped_strings:
+        lowered = text.lower()
+        if any(token in lowered for token in ("bed", "bath", "studio")):
+            parsed = _parse_bed_bath(text)
+            if parsed != (None, None):
+                return parsed
+    return None, None
+
+
 def _parse_listing(container: BeautifulSoup, base_url: str) -> Optional[Unit]:
-    link = container.select_one("a[href*='/listings/detail']") or container.select_one("a[href]")
+    link = (
+        container.select_one("a[href*='/listings/detail']")
+        or container.select_one("a[href*='/listings/']")
+        or container.select_one("a[href]")
+    )
     href = link.get("href") if link else None
     source_url = urljoin(base_url, href) if href else base_url
 
-    address: Optional[str] = None
-    for selector in (
-        ".js-listing-address",
-        ".listing-item__address",
-        ".listing-item__title a",
-        ".listing-item__title",
-    ):
-        address_el = container.select_one(selector)
-        if address_el and address_el.get_text(strip=True):
-            address = address_el.get_text(strip=True)
-            break
-
-    rent = _extract_rent(container)
-    bedrooms, bathrooms = _extract_beds_baths(container)
+    address = _extract_address(container)
+    rent = _extract_rent_appfolio(container)
+    bedrooms, bathrooms = _extract_beds_baths_appfolio(container)
 
     if not address and not source_url:
         return None
@@ -149,8 +242,36 @@ def _parse_listing(container: BeautifulSoup, base_url: str) -> Optional[Unit]:
 def parse_listings(html: str, *, base_url: str = LISTINGS_URL) -> List[Unit]:
     soup = BeautifulSoup(html, "lxml")
 
-    containers = soup.select("div.listing-item")
-    logger.debug("Anchor Realty parser located %d potential listing containers", len(containers))
+    container_selectors = (
+        "[data-testid='listing-card']",
+        "[data-testid='listingCard']",
+        "div.listing-card",
+        "div.listings__item",
+        "li.listings__item",
+        "div.property-item",
+        "div.listing-item",
+    )
+
+    containers = []
+    seen = set()
+    for selector in container_selectors:
+        for node in soup.select(selector):
+            identifier = id(node)
+            if identifier in seen:
+                continue
+            seen.add(identifier)
+            containers.append(node)
+
+    if not containers:
+        # Fallback: treat anchors pointing to listings as potential containers.
+        containers = []
+        for anchor in soup.select("a[href*='/listings']"):
+            parent = anchor.parent
+            containers.append(parent or anchor)
+
+    logger.debug(
+        "Anchor Realty parser located %d potential listing containers", len(containers)
+    )
 
     units: List[Unit] = []
     for idx, container in enumerate(containers):
@@ -168,12 +289,27 @@ def parse_listings(html: str, *, base_url: str = LISTINGS_URL) -> List[Unit]:
     return units
 
 
-def fetch_units(url: str = LISTINGS_URL, *, timeout: int = 20) -> List[Unit]:
-    logger.debug("Fetching Anchor Realty listings from %s", url)
-    response = requests.get(url, headers=HEADERS, timeout=timeout)
-    response.raise_for_status()
-    logger.debug("Anchor Realty HTTP %s (%d bytes)", response.status_code, len(response.content))
-    return parse_listings(response.text, base_url=url)
+def fetch_units(
+    urls: Optional[Union[str, List[str], Tuple[str, ...]]] = None, *, timeout: int = 20
+) -> List[Unit]:
+    if urls is None:
+        url_list = list(LISTING_URLS)
+    elif isinstance(urls, str):
+        url_list = [urls]
+    else:
+        url_list = list(urls)
+
+    units: List[Unit] = []
+    for url in url_list:
+        logger.debug("Fetching Anchor Realty listings from %s", url)
+        response = requests.get(url, headers=HEADERS, timeout=timeout)
+        response.raise_for_status()
+        logger.debug(
+            "Anchor Realty HTTP %s (%d bytes)", response.status_code, len(response.content)
+        )
+        units.extend(parse_listings(response.text, base_url=url))
+
+    return units
 
 
 fetch_units.default_url = LISTINGS_URL  # type: ignore[attr-defined]

--- a/parser/tests/test_anchorealty_scraper.py
+++ b/parser/tests/test_anchorealty_scraper.py
@@ -5,29 +5,19 @@ from parser.scrapers.anchorealty_scraper import LISTINGS_URL, parse_listings
 
 def test_parse_listings_extracts_core_fields():
     html = """
-    <div class="listing-item" id="listing_514">
-        <div class="listing-item__figure-container">
-            <a href="/listings/detail/fc8f831b-268d-4da3-99ba-a669670d39b7">
-                <div class="listing-item__figure">
-                    <div class="listing-item__blurb">
-                        <div class="rent-banner__text js-listing-blurb-rent">$2,595</div>
-                        <span class="rent-banner__text js-listing-blurb-bed-bath">Studio / 1 ba</span>
-                    </div>
-                </div>
-            </a>
-        </div>
-        <div class="listing-item__body">
-            <h2 class="listing-item__title">
-                <a href="/listings/detail/fc8f831b-268d-4da3-99ba-a669670d39b7">
-                    Renovated Nob Hill Studio with In Unit Laundry!
-                </a>
-            </h2>
-            <p>
-                <span class="u-pad-rm js-listing-address">
+    <div class="listing-card" data-testid="listing-card">
+        <a class="listing-card__link" href="/listings/detail/fc8f831b-268d-4da3-99ba-a669670d39b7">
+            <div class="listing-card__header">
+                <h3 class="listing-card__title">Renovated Nob Hill Studio with In Unit Laundry!</h3>
+                <div class="listing-card__address" data-testid="listing-card-address">
                     1684 Washington Street #2, San Francisco, CA 94109
-                </span>
-            </p>
-        </div>
+                </div>
+            </div>
+            <div class="listing-card__rent" data-testid="listing-card-rent">$2,595 / month</div>
+            <div class="listing-card__details">
+                <span data-testid="listing-card-bed-bath">Studio / 1 ba</span>
+            </div>
+        </a>
     </div>
     """
 
@@ -40,7 +30,7 @@ def test_parse_listings_extracts_core_fields():
     assert unit.bedrooms == 0
     assert unit.bathrooms == 1
     assert unit.source_url == (
-        "https://anchorealtyinc.com/listings/detail/"
+        "https://anchorrlty.appfolio.com/listings/detail/"
         "fc8f831b-268d-4da3-99ba-a669670d39b7"
     )
 
@@ -48,12 +38,10 @@ def test_parse_listings_extracts_core_fields():
 def test_parse_listings_handles_missing_values():
     html = """
     <div>
-        <div class="listing-item">
-            <div class="listing-item__body">
-                <span class="js-listing-address">1200 Pine St</span>
-            </div>
+        <div class="listing-card" data-testid="listing-card" data-address="1200 Pine St">
+            <div class="listing-card__details"></div>
         </div>
-        <div class="listing-item">
+        <div class="listing-card">
             <a href="/listings/detail/abc"></a>
         </div>
     </div>
@@ -69,4 +57,4 @@ def test_parse_listings_handles_missing_values():
     assert first.bathrooms is None
 
     assert second.address is None
-    assert second.source_url == "https://anchorealtyinc.com/listings/detail/abc"
+    assert second.source_url == "https://anchorrlty.appfolio.com/listings/detail/abc"


### PR DESCRIPTION
## Summary
- switch the Anchor Realty scraper to pull data from the Anchor AppFolio listing endpoints
- expand the parser with heuristics for the AppFolio listing-card markup while keeping legacy fallbacks
- update tests to reflect the new structure and ensure robustness for missing values

## Testing
- pytest parser/tests/test_anchorealty_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68de976936ac8330b17548cd44743e04