### PR TITLE
Clean up legacy Structure scraper paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,12 @@ parser-cli --html downloads/mission.html --url https://example.com/listing-page 
 
 This command parses the saved HTML file, extracts unique listings, and prints a prettified JSON array—ready for downstream filtering and alerting logic.
 
+## Dynamic rendering support
+
+Some providers, such as Structure Properties, now require JavaScript execution to reveal their unit cards. The bundled scraper
+automatically uses Playwright when available to fetch the fully rendered markup. Install Playwright alongside the Python depende
+ncies and run `playwright install chromium` to ensure the headless browser is ready. The scraper will gracefully fall back to a
+traditional HTTP client if Playwright is missing, but dynamic-only listings may be absent from the results in that mode.
+
 ## Testing
 ⚠️ Tests not run (not requested).

--- a/parser/scrapers/structure_scraper.py
+++ b/parser/scrapers/structure_scraper.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import logging
+import random
 import re
+import time
+from dataclasses import dataclass
 from typing import Any, Iterable, List, Optional
 from urllib.parse import urljoin
-
-import random
-import time
 
 import requests
 from bs4 import BeautifulSoup, Tag
@@ -20,6 +20,16 @@ try:  # pragma: no cover - optional dependency
     import httpx  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - fallback path
     httpx = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from playwright.sync_api import (  # type: ignore
+        Error as PlaywrightError,
+        TimeoutError as PlaywrightTimeoutError,
+        sync_playwright,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback path
+    PlaywrightError = PlaywrightTimeoutError = Exception  # type: ignore
+    sync_playwright = None  # type: ignore
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +51,102 @@ HEADERS = {
 _price_re = re.compile(r"\$?\s*([0-9][\d,]*)(?:\.\d+)?", re.I)
 _beds_re  = re.compile(r"(\d+(?:\.\d+)?)\s*(?:bed|beds|br)\b", re.I)
 _baths_re = re.compile(r"(\d+(?:\.\d+)?)\s*(?:bath|baths|ba)\b", re.I)
+
+_PLAYWRIGHT_WAIT_SELECTOR = ",".join(
+    [
+        ".listing-item",
+        ".property-item",
+        "article.property",
+        "article.listing",
+        ".rentpress-listing-card",
+    ]
+)
+
+
+@dataclass
+class _PlaywrightResponse:
+    status_code: int
+    text: str
+
+    def __post_init__(self) -> None:
+        self.content = self.text.encode("utf-8")
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class _PlaywrightSession:
+    """Minimal Playwright wrapper with a requests-like interface."""
+
+    def __init__(self, timeout: int = 20) -> None:
+        if sync_playwright is None:  # pragma: no cover - safety net
+            raise RuntimeError("Playwright is not available")
+        self._timeout = max(timeout, 1)
+        self._playwright = sync_playwright().start()
+        self._browser = self._playwright.chromium.launch(headless=True)
+
+        extra_headers = {k: v for k, v in HEADERS.items() if k.lower() != "user-agent"}
+        self._context = self._browser.new_context(
+            user_agent=HEADERS.get("User-Agent"),
+            extra_http_headers=extra_headers,
+        )
+        self._page = self._context.new_page()
+        timeout_ms = self._timeout * 1000
+        self._page.set_default_timeout(timeout_ms)
+        self._page.set_default_navigation_timeout(timeout_ms)
+
+    def _resolve_timeout_ms(self, timeout: Any) -> int:
+        if timeout is None:
+            return self._timeout * 1000
+        try:
+            if isinstance(timeout, (int, float)):
+                return int(float(timeout) * 1000)
+            for attr in ("read", "read_timeout", "timeout", "total"):
+                value = getattr(timeout, attr, None)
+                if value is not None:
+                    return int(float(value) * 1000)
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return self._timeout * 1000
+
+    def get(self, url: str, *, headers: Optional[dict[str, str]] = None, timeout: Any = None) -> _PlaywrightResponse:
+        referer = headers.get("Referer") if headers else None
+        timeout_ms = self._resolve_timeout_ms(timeout)
+        try:
+            response = self._page.goto(
+                url,
+                referer=referer,
+                wait_until="networkidle",
+                timeout=timeout_ms,
+            )
+            # Give dynamic scripts a moment to populate listings.
+            try:
+                self._page.wait_for_selector(_PLAYWRIGHT_WAIT_SELECTOR, timeout=2000)
+            except Exception:  # pragma: no cover - best-effort wait
+                pass
+            html = self._page.content()
+            status = response.status if response else 200
+        except PlaywrightTimeoutError as exc:  # pragma: no cover - network flake
+            logger.warning("Playwright navigation timeout for %s: %s", url, exc)
+            html = self._page.content()
+            status = 408
+        except PlaywrightError as exc:  # pragma: no cover - unexpected failure
+            logger.error("Playwright error navigating to %s: %s", url, exc)
+            raise
+        return _PlaywrightResponse(status_code=status, text=html)
+
+    def close(self) -> None:
+        try:
+            self._page.close()
+        finally:
+            try:
+                self._context.close()
+            finally:
+                try:
+                    self._browser.close()
+                finally:
+                    self._playwright.stop()
 
 def _clean_price(text: Optional[str]) -> Optional[int]:
     if not text:
@@ -68,13 +174,6 @@ def _clean_float(text: Optional[str], kind: str) -> Optional[float]:
         return float(grp)
     except Exception:
         return None
-
-def _get_html(url: str, timeout: int = 20) -> str:
-    logger.debug("Structure Properties legacy fetch %s", url)
-    resp = requests.get(url, headers=HEADERS, timeout=timeout)
-    resp.raise_for_status()
-    logger.debug("Structure Properties legacy HTTP %s (%d bytes)", resp.status_code, len(resp.content))
-    return resp.text
 
 def _candidate_listing_blocks(soup: BeautifulSoup) -> Iterable[Tag]:
     selectors = [
@@ -200,77 +299,42 @@ def _find_next_page(soup: BeautifulSoup, current_url: str) -> Optional[str]:
             return urljoin(current_url, nxt["href"])
     return None
 
-def parse(max_pages: int = 10) -> List[Unit]:
-    """
-    Scrape Structure Properties available rentals across paginated results.
-
-    Follows common pagination patterns until no 'next' is found or max_pages is reached.
-    Returns a list of Unit objects.
-    """
-    url = SEARCH_URL
-    visited: set[str] = set()
-    units: List[Unit] = []
-    pages = 0
-
-    session = requests.Session()
-
-    while url and pages < max_pages and url not in visited:
-        visited.add(url)
-        pages += 1
-
-        logger.debug("Structure Properties legacy pagination fetch %s", url)
-        resp = session.get(url, headers=HEADERS, timeout=20)
-        resp.raise_for_status()
-        soup = BeautifulSoup(resp.text, "lxml")
-
-        blocks = list(_candidate_listing_blocks(soup))
-        if not blocks:
-            blocks = soup.find_all("article")
-        logger.debug(
-            "Structure Properties legacy page %d yielded %d block(s)",
-            pages,
-            len(blocks),
-        )
-
-        for b in blocks:
-            unit = _parse_block(b, base_url=url)
-            if unit:
-                units.append(unit)
-
-        url = _find_next_page(soup, current_url=url)
-
-    return units
-
 def get_html(url: str, client: Any, referer: Optional[str] = None) -> str:
     headers = HEADERS.copy()
     if referer:
         headers["Referer"] = referer
     logger.debug("Structure Properties request %s (referer=%s)", url, referer)
-    for attempt in range(3):
-        timeout = httpx.Timeout(20.0) if httpx else 20.0  # type: ignore[union-attr]
+    attempts = 3
+    timeout = httpx.Timeout(20.0) if httpx else 20.0  # type: ignore[union-attr]
+    for attempt in range(1, attempts + 1):
         r = client.get(url, headers=headers, timeout=timeout)
         if r.status_code == 200:
             logger.debug(
                 "Structure Properties HTTP %s on attempt %d (%d bytes)",
                 r.status_code,
-                attempt + 1,
+                attempt,
                 len(r.content),
             )
             return r.text
-        if r.status_code in (403, 429, 503):
-            time.sleep(1.0 + attempt + random.uniform(0, 0.5))
+        if r.status_code in (403, 429, 503) and attempt < attempts:
+            sleep_for = 1.0 + attempt - 1 + random.uniform(0, 0.5)
+            logger.debug(
+                "Structure Properties retrying after %s due to status %s", sleep_for, r.status_code
+            )
+            time.sleep(sleep_for)
             continue
         r.raise_for_status()
-    # final try or raise
-    timeout = httpx.Timeout(20.0) if httpx else 20.0  # type: ignore[union-attr]
-    r = client.get(url, headers=headers, timeout=timeout)
-    r.raise_for_status()
-    logger.debug(
-        "Structure Properties final retry HTTP %s (%d bytes)",
-        r.status_code,
-        len(r.content),
-    )
+    # If we exit the loop the last response succeeded or raise_for_status() raised.
     return r.text
+
+def _create_http_client() -> tuple[Any, Any]:
+    if httpx is not None:
+        client = httpx.Client(http2=True, follow_redirects=True, headers=HEADERS)
+        return client, client.close
+    session = requests.Session()
+    session.headers.update(HEADERS)
+    return session, session.close
+
 
 def fetch_units(url: str = SEARCH_URL, *, max_pages: int = 10, timeout: int = 20) -> List[Unit]:
     """
@@ -283,13 +347,20 @@ def fetch_units(url: str = SEARCH_URL, *, max_pages: int = 10, timeout: int = 20
 
     logger.debug("Fetching Structure Properties listings from %s (max_pages=%d)", url, max_pages)
 
-    if httpx is not None:
-        client = httpx.Client(http2=True, follow_redirects=True, headers=HEADERS)
-        close_client = client.close
-    else:  # pragma: no cover - fallback when httpx is unavailable
-        client = requests.Session()
-        client.headers.update(HEADERS)
-        close_client = client.close
+    client: Any
+    close_client: Any
+    if sync_playwright is not None:
+        try:
+            client = _PlaywrightSession(timeout=timeout)
+            close_client = client.close
+            logger.debug("Using Playwright rendered session for Structure Properties")
+        except Exception as exc:  # pragma: no cover - Playwright init issues
+            logger.warning(
+                "Playwright unavailable (%s); falling back to HTTP session", exc
+            )
+            client, close_client = _create_http_client()
+    else:
+        client, close_client = _create_http_client()
 
     # 1) warm up
     try:
@@ -339,4 +410,4 @@ def fetch_units(url: str = SEARCH_URL, *, max_pages: int = 10, timeout: int = 20
 
 fetch_units.default_url = SEARCH_URL  # type: ignore[attr-defined]
 
-__all__ = ["fetch_units", "parse"]
+__all__ = ["fetch_units"]


### PR DESCRIPTION
## Summary
- wrap Structure Properties scraping in a Playwright-powered session to capture rendered unit markup
- fall back to the existing HTTP client when Playwright is unavailable and keep pagination parsing unchanged
- document the optional Playwright dependency for dynamic listings in the README
- remove the unused legacy requests-only scraper path now that the Playwright-enabled flow is primary
- streamline the HTTP retry loop for clearer backoff handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df521334488330b147af0db5dd56ca