### PR TITLE
Improve RentBT scraper headers and referer handling

### DIFF
--- a/parser/scrapers/rentbt_scraper.py
+++ b/parser/scrapers/rentbt_scraper.py
@@ -33,6 +33,14 @@ HEADERS = {
     "Accept-Language": "en-US,en;q=0.9",
     "Connection": "keep-alive",
     "Accept-Encoding": "gzip, deflate, br",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-User": "?1",
+    "Sec-Fetch-Dest": "document",
+    "sec-ch-ua": '"Not.A/Brand";v="8", "Chromium";v="120", "Google Chrome";v="120"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
 }
 
 LANDING_URL = "https://properties.rentbt.com/"
@@ -73,8 +81,9 @@ def _get_page(
     referer: Optional[str] = None,
 ) -> str:
     headers = HEADERS.copy()
-    if referer:
-        headers["Referer"] = referer
+    referer_header = referer or LANDING_URL
+    if referer_header:
+        headers["Referer"] = referer_header
 
     if httpx is not None and isinstance(client, httpx.Client):  # type: ignore[arg-type]
         response = client.get(url, headers=headers, timeout=httpx.Timeout(timeout))

--- a/parser/tests/test_rentbt_scraper.py
+++ b/parser/tests/test_rentbt_scraper.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 import textwrap
 
-from parser.scrapers.rentbt_scraper import parse_listings, set_page_number
+import requests
+
+from parser.scrapers.rentbt_scraper import (
+    HEADERS,
+    LANDING_URL,
+    _get_page,
+    parse_listings,
+    set_page_number,
+)
 
 
 def test_parse_listings_extracts_key_fields():
@@ -55,3 +63,54 @@ def test_set_page_number_updates_querystring():
     assert "PgNo=2" in second
     first = set_page_number(second, 1)
     assert "PgNo=" not in first
+
+
+def test_headers_include_modern_chrome_fields():
+    assert "Upgrade-Insecure-Requests" in HEADERS
+    assert "Sec-Fetch-Site" in HEADERS
+    assert "Sec-Fetch-Mode" in HEADERS
+    assert "Sec-Fetch-User" in HEADERS
+    assert "Sec-Fetch-Dest" in HEADERS
+    assert HEADERS.get("sec-ch-ua") is not None
+    assert HEADERS.get("sec-ch-ua-mobile") == "?0"
+    assert HEADERS.get("sec-ch-ua-platform") == '"Windows"'
+    assert "Referer" not in HEADERS
+
+
+class _StubResponse:
+    def __init__(self, url: str, headers: dict[str, str]):
+        self.url = url
+        self._headers = headers
+        self.text = "ok"
+        self.cookies = requests.cookies.RequestsCookieJar()
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+class _StubClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, str]]] = []
+        self.cookies = requests.cookies.RequestsCookieJar()
+
+    def get(self, url: str, headers: dict[str, str], timeout: int):
+        self.calls.append((url, headers))
+        return _StubResponse(url, headers)
+
+
+def test_get_page_populates_referer_header_by_default():
+    client = _StubClient()
+
+    _get_page(LANDING_URL, client=client, timeout=5)
+
+    assert client.calls, "Expected at least one request to be recorded"
+    first_url, first_headers = client.calls[0]
+    assert first_url == LANDING_URL
+    assert first_headers["Referer"] == LANDING_URL
+
+    next_url = set_page_number(first_url, 2)
+    _get_page(next_url, client=client, timeout=5, referer=first_url)
+
+    assert len(client.calls) == 2
+    _, second_headers = client.calls[1]
+    assert second_headers["Referer"] == first_url

--- a/parser/workflow.py
+++ b/parser/workflow.py
@@ -159,7 +159,10 @@ def filter_units(
 def _prepare_registry(
     scrapers: Optional[Dict[str, ScraperFunc]] = None,
 ) -> Dict[str, ScraperFunc]:
-    registry = scrapers or available_scrapers()
+    if scrapers is None:
+        registry = available_scrapers()
+    else:
+        registry = scrapers
     return {_normalise_slug(slug): scraper for slug, scraper in registry.items()}
 
 


### PR DESCRIPTION
## Summary
- add modern Chrome network headers to RentBT scraper requests and ensure a default referer is set
- extend scraper tests to cover header contents and referer propagation
- prevent workflow registry from auto-loading defaults when an explicit scraper mapping is supplied

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dffd9a1bd88330974e0733807d35e5