### PR TITLE
Add Mosser Living scraper

### DIFF
--- a/parser/scrapers/__init__.py
+++ b/parser/scrapers/__init__.py
@@ -69,6 +69,13 @@ def _load_default_scrapers() -> Dict[str, ScraperFunc]:
     else:
         registry["rentsfnow"] = rentsfnow_fetch
 
+    try:
+        from .mosser_scraper import fetch_units as mosser_fetch
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        missing.append(getattr(exc, "name", "mosser_scraper dependency"))
+    else:
+        registry["mosser"] = mosser_fetch
+
     if not registry and missing:
         details = ", ".join(sorted(set(filter(None, missing))))
         raise RuntimeError(

--- a/parser/scrapers/mosser_scraper.py
+++ b/parser/scrapers/mosser_scraper.py
@@ -1,0 +1,214 @@
+"""Scraper for Mosser Living San Francisco listings."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List, Optional, Tuple
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
+from parser.heuristics import clean_neighborhood, money_to_int, parse_bathrooms, parse_bedrooms
+from parser.models import Unit
+
+DEFAULT_URL = "https://www.mosserliving.com/san-francisco-apartments/all/"
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _extract_json_data(tag: Tag) -> Optional[dict[str, Any]]:
+    script = tag.find("script", attrs={"type": "application/ld+json"})
+    if not script or not script.string:
+        return None
+    try:
+        data = json.loads(script.string)
+    except json.JSONDecodeError:
+        _LOGGER.debug("Failed to parse JSON-LD block", exc_info=True)
+        return None
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                return item
+        return None
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def _parse_property_card(
+    card: Tag, *, base_url: str
+) -> Optional[Tuple[str, Optional[str], Optional[str]]]:
+    anchor = card.find("a", href=True)
+    if not anchor:
+        return None
+    property_url = urljoin(base_url, anchor["href"])
+
+    data = _extract_json_data(card)
+    address: Optional[str] = None
+    neighborhood: Optional[str] = None
+
+    subtitle = anchor.select_one(".v-card__subtitle")
+    if subtitle:
+        text = subtitle.get_text(" ", strip=True)
+        cleaned = clean_neighborhood(text)
+        neighborhood = cleaned or None
+
+    if data:
+        address_info = data.get("address")
+        if isinstance(address_info, dict):
+            address = address_info.get("streetAddress") or address_info.get("addressLocality")
+            if neighborhood is None:
+                locality = address_info.get("addressLocality")
+                region = address_info.get("addressRegion")
+                components = [part for part in [locality, region] if part]
+                if components:
+                    neighborhood = clean_neighborhood(", ".join(components)) or None
+
+        if not neighborhood:
+            name = data.get("name")
+            if isinstance(name, str):
+                neighborhood = clean_neighborhood(name) or None
+
+    if not address:
+        title = anchor.select_one(".rentpress-property-card-title")
+        if title:
+            address = title.get_text(strip=True) or None
+
+    return property_url, address, neighborhood
+
+
+def parse_property_list(html: str, *, base_url: str = DEFAULT_URL) -> List[Tuple[str, Optional[str], Optional[str]]]:
+    """Return property detail URLs with associated metadata."""
+
+    soup = BeautifulSoup(html, "lxml")
+    cards = soup.select("div.property-card-wrapper")
+
+    results: List[Tuple[str, Optional[str], Optional[str]]] = []
+    for card in cards:
+        parsed = _parse_property_card(card, base_url=base_url)
+        if parsed is None:
+            continue
+        results.append(parsed)
+
+    return results
+
+
+def _extract_floorplan_details(tag: Tag) -> Tuple[Optional[float], Optional[float], Optional[int]]:
+    info_el = tag.select_one(".v-card__subtitle")
+    info_text = info_el.get_text(" ", strip=True) if info_el else ""
+
+    bedrooms = parse_bedrooms(info_text)
+    bathrooms = parse_bathrooms(info_text)
+
+    rent_text = tag.get_text(" ", strip=True)
+    rent = money_to_int(rent_text)
+
+    return bedrooms, bathrooms, rent
+
+
+def parse_property_page(
+    html: str,
+    *,
+    property_url: str,
+    address: Optional[str],
+    neighborhood: Optional[str],
+) -> List[Unit]:
+    """Parse an individual property page into :class:`Unit` objects."""
+
+    soup = BeautifulSoup(html, "lxml")
+    cards = soup.select("div.rentpress-remove-link-decoration > a[href]")
+
+    units: List[Unit] = []
+    for anchor in cards:
+        card = anchor.find(class_="rentpress-shortcode-floorplan-card")
+        card = card or anchor
+
+        bedrooms, bathrooms, rent = _extract_floorplan_details(card)
+
+        source_url = urljoin(property_url, anchor.get("href", "")) or property_url
+
+        units.append(
+            Unit(
+                address=address,
+                bedrooms=bedrooms,
+                bathrooms=bathrooms,
+                rent=rent,
+                neighborhood=neighborhood,
+                source_url=source_url,
+            )
+        )
+
+    return units
+
+
+def fetch_units(
+    url: str = DEFAULT_URL,
+    *,
+    timeout: int = 20,
+    session: Optional[Any] = None,
+) -> List[Unit]:
+    """Fetch Mosser Living listings and return them as :class:`Unit` objects."""
+
+    client: Any
+    close_session = False
+
+    if session is not None:
+        client = session
+    else:
+        client = requests.Session()
+        close_session = True
+
+    try:
+        if hasattr(client, "headers"):
+            try:
+                client.headers.update(HEADERS)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        response = client.get(url, headers=HEADERS, timeout=timeout)
+        response.raise_for_status()
+
+        properties = parse_property_list(response.text, base_url=url)
+        units: List[Unit] = []
+
+        for property_url, address, neighborhood in properties:
+            try:
+                detail = client.get(property_url, headers=HEADERS, timeout=timeout)
+                detail.raise_for_status()
+            except requests.RequestException as exc:  # pragma: no cover - network failure
+                _LOGGER.warning("Failed to fetch property page %s: %s", property_url, exc)
+                continue
+
+            units.extend(
+                parse_property_page(
+                    detail.text,
+                    property_url=property_url,
+                    address=address,
+                    neighborhood=neighborhood,
+                )
+            )
+
+        return units
+    finally:
+        if close_session:
+            try:
+                client.close()
+            except Exception:  # pragma: no cover - best effort
+                pass
+
+
+fetch_units.default_url = DEFAULT_URL  # type: ignore[attr-defined]

--- a/parser/tests/test_mosser_scraper.py
+++ b/parser/tests/test_mosser_scraper.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import textwrap
+
+from parser.scrapers import mosser_scraper as ms
+
+
+def test_parse_property_list_returns_urls_and_metadata():
+    html = textwrap.dedent(
+        """
+        <div class="property-card-wrapper">
+          <div>
+            <a href="https://www.mosserliving.com/apartments/419-pierce/">
+              <div class="rentpress-property-card-title">419 Pierce</div>
+              <div class="v-card__subtitle">Alamo Square, San Francisco, CA</div>
+              <script type="application/ld+json">
+              {
+                "@context": "https://schema.org/",
+                "@type": "ApartmentComplex",
+                "address": {
+                  "@type": "PostalAddress",
+                  "streetAddress": "419 Pierce St",
+                  "addressLocality": "San Francisco",
+                  "addressRegion": "CA"
+                }
+              }
+              </script>
+            </a>
+          </div>
+        </div>
+        """
+    )
+
+    results = ms.parse_property_list(html)
+
+    assert len(results) == 1
+    url, address, neighborhood = results[0]
+    assert url == "https://www.mosserliving.com/apartments/419-pierce/"
+    assert address == "419 Pierce St"
+    assert neighborhood == "Alamo Square"
+
+
+def test_parse_property_page_extracts_unit_details():
+    html = textwrap.dedent(
+        """
+        <div class="rentpress-remove-link-decoration">
+          <a href="/floorplans/studio-plan-4/">
+            <div class="rentpress-shortcode-floorplan-card">
+              <div class="v-card__subtitle">
+                <div><span> Studio | 1 Bath </span></div>
+              </div>
+              <div class="v-card__text">
+                <div class="rentpress-inherited-font-family text-body-1 font-italic col col-auto">
+                  Starting at $2,475
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+        """
+    )
+
+    units = ms.parse_property_page(
+        html,
+        property_url="https://www.mosserliving.com/apartments/419-pierce/",
+        address="419 Pierce St",
+        neighborhood="Alamo Square",
+    )
+
+    assert len(units) == 1
+    unit = units[0]
+    assert unit.address == "419 Pierce St"
+    assert unit.bedrooms == 0.0
+    assert unit.bathrooms == 1.0
+    assert unit.rent == 2475
+    assert (
+        unit.source_url
+        == "https://www.mosserliving.com/floorplans/studio-plan-4/"
+    )
+    assert unit.neighborhood == "Alamo Square"
+
+
+class _StubResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial stub
+        return None
+
+
+class _StubSession:
+    def __init__(self, pages: dict[str, str]) -> None:
+        self.pages = pages
+        self.headers: dict[str, str] = {}
+        self.calls: list[str] = []
+
+    def get(self, url: str, headers: dict[str, str], timeout: int) -> _StubResponse:
+        self.calls.append(url)
+        try:
+            return _StubResponse(self.pages[url])
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise AssertionError(f"Unexpected URL requested: {url}") from exc
+
+    def close(self) -> None:  # pragma: no cover - stub behaviour
+        return None
+
+
+def test_fetch_units_aggregates_units_across_properties():
+    listing_html = textwrap.dedent(
+        """
+        <div class="property-card-wrapper">
+          <div>
+            <a href="https://www.mosserliving.com/apartments/419-pierce/">
+              <div class="rentpress-property-card-title">419 Pierce</div>
+              <div class="v-card__subtitle">Alamo Square, San Francisco, CA</div>
+              <script type="application/ld+json">
+              {
+                "address": {
+                  "streetAddress": "419 Pierce St"
+                }
+              }
+              </script>
+            </a>
+          </div>
+        </div>
+        """
+    )
+    property_html = textwrap.dedent(
+        """
+        <div class="rentpress-remove-link-decoration">
+          <a href="/floorplans/studio-plan-4/">
+            <div class="rentpress-shortcode-floorplan-card">
+              <div class="v-card__subtitle">
+                <div><span> Studio | 1 Bath </span></div>
+              </div>
+              <div class="v-card__text">
+                <div class="rentpress-inherited-font-family text-body-1 font-italic col col-auto">
+                  Starting at $2,475
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+        """
+    )
+
+    pages = {
+        ms.DEFAULT_URL: listing_html,
+        "https://www.mosserliving.com/apartments/419-pierce/": property_html,
+    }
+    session = _StubSession(pages)
+
+    units = ms.fetch_units(session=session)
+
+    assert len(units) == 1
+    unit = units[0]
+    assert unit.rent == 2475
+    assert unit.address == "419 Pierce St"
+    assert session.calls[0] == ms.DEFAULT_URL
+    assert session.calls[1] == "https://www.mosserliving.com/apartments/419-pierce/"


### PR DESCRIPTION
## Summary
- implement a Mosser Living scraper that walks property listings and floorplan cards
- register the new scraper in the scraper registry
- cover the scraper with unit tests for parsing and fetch aggregation

## Testing
- pytest parser/tests/test_mosser_scraper.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1f400ef188330ba60559af54b1318