### PR TITLE
Point Gaetani scraper default URL to AppFolio API

### DIFF
--- a/parser/scrapers/__init__.py
+++ b/parser/scrapers/__init__.py
@@ -83,6 +83,13 @@ def _load_default_scrapers() -> Dict[str, ScraperFunc]:
     else:
         registry["mosser"] = mosser_fetch
 
+    try:
+        from .gaetanirealestate_scraper import fetch_units as gaetani_fetch
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        missing.append(getattr(exc, "name", "gaetanirealestate_scraper dependency"))
+    else:
+        registry["gaetanirealestate"] = gaetani_fetch
+
     if not registry and missing:
         details = ", ".join(sorted(set(filter(None, missing))))
         raise RuntimeError(

--- a/parser/scrapers/gaetanirealestate_scraper.py
+++ b/parser/scrapers/gaetanirealestate_scraper.py
@@ -1,0 +1,48 @@
+"""Scraper for Gaetani Real Estate AppFolio listings."""
+
+from __future__ import annotations
+
+from typing import List
+
+import requests
+
+from parser.models import Unit
+from parser.scrapers.jacksongroup_scraper import (
+    parse_appfolio_collection as _parse_appfolio_collection,
+)
+
+LISTINGS_URL = "https://www.gaetanirealestate.com/vacancies"
+APPFOLIO_API_URL = (
+    "https://www.gaetanirealestate.com/rts/collections/public/"
+    "31f9c706/runtime/collection/appfolio-listings/data?page=%7B%22pageSize%22%3A100%2C"
+    "%22pageNumber%22%3A0%7D&language=ENGLISH"
+)
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/javascript, */*; q=0.01",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Connection": "keep-alive",
+}
+
+parse_appfolio_collection = _parse_appfolio_collection
+
+
+def fetch_units(url: str = APPFOLIO_API_URL, *, timeout: int = 20) -> List[Unit]:
+    """Fetch Gaetani Real Estate listings from the published AppFolio endpoint."""
+
+    response = requests.get(url, headers=HEADERS, timeout=timeout)
+    response.raise_for_status()
+
+    payload = response.json()
+    return parse_appfolio_collection(payload, base_url=LISTINGS_URL)
+
+
+fetch_units.default_url = APPFOLIO_API_URL  # type: ignore[attr-defined]
+
+
+__all__ = ["fetch_units", "parse_appfolio_collection", "APPFOLIO_API_URL", "LISTINGS_URL"]

--- a/parser/tests/test_gaetanirealestate_scraper.py
+++ b/parser/tests/test_gaetanirealestate_scraper.py
@@ -1,0 +1,82 @@
+import pytest
+
+from parser.scrapers import gaetanirealestate_scraper as scraper
+
+
+SAMPLE_PAYLOAD = {
+    "values": [
+        {
+            "listing": {
+                "full_address": "123 Main St, San Francisco, CA 94109",
+                "bedrooms": "2",
+                "bathrooms": "1.5",
+                "market_rent": "3450",
+                "listable_uid": "abc123",
+                "database_url": "https://gaetani.appfolio.com/",
+            }
+        },
+        {
+            "listing": {
+                "address_address1": "456 Oak St",
+                "address_city": "San Francisco",
+                "address_state": "CA",
+                "address_postal_code": "94102",
+                "bedrooms": 1,
+                "bathrooms": 1,
+                "rent": 2800,
+                "portfolio_url": "https://gaetani.appfolio.com/listings/detail/xyz789",
+            }
+        },
+    ]
+}
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_parse_appfolio_collection_produces_units():
+    units = scraper.parse_appfolio_collection(SAMPLE_PAYLOAD, base_url=scraper.LISTINGS_URL)
+
+    assert len(units) == 2
+    assert units[0].address == "123 Main St, San Francisco, CA 94109"
+    assert units[0].bedrooms == pytest.approx(2)
+    assert units[0].bathrooms == pytest.approx(1.5)
+    assert units[0].rent == 3450
+    assert units[0].source_url.startswith("https://gaetani.appfolio.com/")
+
+    assert units[1].address == "456 Oak St, San Francisco, CA, 94102"
+    assert units[1].bedrooms == 1
+    assert units[1].bathrooms == 1
+    assert units[1].rent == 2800
+    assert units[1].source_url == "https://gaetani.appfolio.com/listings/detail/xyz789"
+
+
+def test_fetch_units_default_url_uses_api_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_get(url, *, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(scraper.requests, "get", fake_get)
+
+    units = scraper.fetch_units()
+
+    assert captured["url"] == scraper.APPFOLIO_API_URL
+    assert captured["headers"] == scraper.HEADERS
+    assert captured["timeout"] == 20
+    assert len(units) == 2
+
+
+def test_fetch_units_default_url_attribute_points_to_api():
+    assert scraper.fetch_units.default_url == scraper.APPFOLIO_API_URL


### PR DESCRIPTION
## Summary
- add a Gaetani Real Estate AppFolio scraper wrapper and point its default URL at the JSON API
- register the scraper so the workflow continues to use the API endpoint
- add unit coverage confirming the parser output and default URL wiring

## Testing
- pytest parser/tests/test_gaetanirealestate_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ffae9d508330983891d85e8509c5